### PR TITLE
Improve the video frame files scanning time and print progress

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ variables:
   PYTHONPATH: .
 dependencies:
   - pip:
+    - git+https://github.com/ananthsub/pytorch-lightning@a98b070  # See https://github.com/PyTorchLightning/pytorch-lightning/issues/12317
     -            scenedetect
   - conda-forge::accimage
   -              beautifulsoup4
@@ -26,7 +27,7 @@ dependencies:
   - conda-forge::py-rouge=1.1
   -              python=3.9
   -     pytorch::pytorch=*=*cuda*
-  - conda-forge::pytorch-lightning=1.6
+#  - conda-forge::pytorch-lightning=1.6
   - conda-forge::pytube
   -              requests
   - conda-forge::rich  # For fancy output.

--- a/src/clip_decoder_source_training.sh
+++ b/src/clip_decoder_source_training.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-output_ckpt_dir=ckpts/clip_decoder/text_visual_source_trained/
+output_ckpt_dir=ckpts/clip_decoder/text_visual_source_trained
 num_train_epochs=100
 train_batch_size=8
 eval_batch_size=16
-log_dir=logs/clip_decoder/
+log_dir=logs/clip_decoder
 log_path=logs/clip_decoder/source_training_parallel_baseline.log
 max_seq_length=16
 max_vid_length=2048
@@ -15,13 +15,11 @@ mkdir -p ${output_ckpt_dir}
 mkdir -p ${log_dir}
 
 python -m src clip_decoder \
-    --train_data_path example_data/tvqa-data/train.json \
-    --dev_data_path example_data/tvqa-data/val.json \
-    --test_data_path example_data/tvqa-data/val.json \
-    --frames_path video_features/tvqa_frames_hq \
-    --is_tvqa \
-    --n_gpu 4 \
-    --accelerator ddp \
+    --train_data_path /scratch/mihalcea_root/mihalcea0/shared_data/tvqa_private_share/tvqa_qa_release/train.json \
+    --dev_data_path /scratch/mihalcea_root/mihalcea0/shared_data/tvqa_private_share/tvqa_qa_release/val.json \
+    --test_data_path /scratch/mihalcea_root/mihalcea0/shared_data/tvqa_private_share/tvqa_qa_release/test.json \
+    --frames_path /scratch/mihalcea_root/mihalcea0/shared_data/tvqa_private_share/previously_extracted/extracted_fns/frames_hq \
+    --strategy ddp_find_unused_parameters_false \
     --output_ckpt_dir ${output_ckpt_dir} \
     --num_train_epochs ${num_train_epochs} \
     --train_batch_size ${train_batch_size} \

--- a/src/src/model.py
+++ b/src/src/model.py
@@ -48,14 +48,14 @@ class AnswerWithEvidenceModule(pl.LightningModule, ABC):
     def on_test_start(self) -> None:
         self._on_eval_start()
 
-    def _step(self, batch: TYPE_BATCH, split: TYPE_SPLIT) -> MutableMapping[str, torch.Tensor]:
+    def _step(self, batch: TYPE_BATCH, split: TYPE_SPLIT) -> MutableMapping[str, torch.Tensor]:  # noqa
         return {}
 
     @abstractmethod
     def _generative_step(self, batch: TYPE_BATCH, step_output: MutableMapping[str, torch.Tensor]) -> Mapping[str, Any]:
         raise NotImplementedError
 
-    def _update_metrics(self, batch: TYPE_BATCH, step_output: MutableMapping[str, torch.Tensor],
+    def _update_metrics(self, batch: TYPE_BATCH, step_output: MutableMapping[str, torch.Tensor],  # noqa
                         generative_step_output: Mapping[str, Any], split: TYPE_SPLIT) -> None:
         print("Updating metrics....")
         batch_size = len(batch["question"])

--- a/src/src/parse_args.py
+++ b/src/src/parse_args.py
@@ -52,12 +52,11 @@ class TrainAndTestArguments:
     num_train_epochs: int = 100
     gradient_accumulation_steps: Optional[int] = None
     n_gpu: int = field(
-        default=1,
+        default=-1,
         metadata={"help": "number of gpus used"}
     )
-    accelerator: str = field(
+    strategy: str = field(
         default=None,
-        metadata={"help": "type of accelerator"}
     )
     early_stop_callback: bool = field(
         default=False,
@@ -89,10 +88,6 @@ class TrainAndTestArguments:
     wandb_offline: bool = field(
         default=False,
         metadata={"help": "if set true, we will not have wandb record online"}
-    )
-    is_tvqa: bool = field(
-        default=False,
-        metadata={"help": "if the dataset we use is tvqa dataset"}
     )
 
 

--- a/src/src/train_and_test.py
+++ b/src/src/train_and_test.py
@@ -2,13 +2,11 @@
 import argparse
 import logging
 import os
-import math
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import RichProgressBar
 from pytorch_lightning.loggers import TensorBoardLogger, WandbLogger
 from transformers import AutoTokenizer
-from torch.utils.data import DataLoader, Dataset
 
 from src.closest_rtr.closest_rtr import ClosestAnswerWithEvidenceModule
 from src.mca.mca import MostCommonAnswerWithEvidenceModule
@@ -78,7 +76,7 @@ def train_and_test(args: argparse.Namespace) -> None:
                          max_epochs=args.num_train_epochs, precision=16 if args.fp_16 else 32,
                          amp_level=args.opt_level, gradient_clip_val=args.max_grad_norm, profiler=args.profiler,
                          log_every_n_steps=1, logger=loggers, callbacks=callbacks,
-                         accelerator=args.accelerator)
+                         strategy=args.strategy, deterministic=True)
 
     if should_train:
         trainer.fit(model, datamodule=data_module)

--- a/src/src/transformer_models/model.py
+++ b/src/src/transformer_models/model.py
@@ -253,10 +253,6 @@ class TransformersAnswerWithEvidenceModule(AnswerWithEvidenceModule):
             generated_prob = compute_answer_prob(generated_probs)
             self.log(f"generated_prob/{split}", generated_prob, batch_size=batch_size)
 
-
-    def _num_training_steps(self) -> int:
-        return len(self.trainer.train_dataloader) * max(self.trainer.num_train_epochs, 1)  # * self.trainer.gradient_accumulation_steps
-
     @overrides
     def configure_optimizers(self) -> Mapping[str, Any]:
         no_decay = {"bias", "LayerNorm.weight"}
@@ -272,16 +268,7 @@ class TransformersAnswerWithEvidenceModule(AnswerWithEvidenceModule):
         ]
         optimizer = AdamW(optimizer_grouped_parameters, lr=self.hparams.learning_rate, eps=self.hparams.adam_epsilon)
 
-        # NOTE: issues with the scheduling for mult-GPU training, specifically with estimated stepping batches
-        # https://github.com/PyTorchLightning/pytorch-lightning/issues/12317
-        # Issues not fixed yet at Pytorch_lightning version 1.6.1. 
-        # https://github.com/PyTorchLightning/pytorch-lightning/pull/11952#
-
-        self.trainer.reset_train_dataloader()
-        num_training_steps = self._num_training_steps()
-
         scheduler = get_linear_schedule_with_warmup(optimizer, num_warmup_steps=self.hparams.warmup_steps,
-                                                    num_training_steps=num_training_steps)
+                                                    num_training_steps=self.trainer.estimated_stepping_batches)
 
         return {"optimizer": optimizer, "lr_scheduler": {"scheduler": scheduler, "interval": "step"}}
-


### PR DESCRIPTION
I changed the scanning of frame images in the dataset to just the video folders. It's a bit faster. I also made it print the progress, so we know what the program is doing while we wait for it.

Still, I think it can be improved further. It feels like we shouldn't have to scan the dirs, as we can later (during the `__getitem__` call) just read one folder without needing to scan anything before.

Also, I changed the dependencies to use the patched PL version so to have the fix for the estimated num steps. (Recall to do an env update after this is merged!)

Note this is a PR against the branch `parallel`, not `master`.